### PR TITLE
fix: CI now should emit APK-s

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,4 +29,4 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: android-app
-                  path: app/build/outputs/apk/*/*/*.apk
+                  path: app/build/outputs/apk/*/*.apk


### PR DESCRIPTION
I checked the actual path and it seems that too many \* was used before.
I assume, you could've just used \*\* though. But anyways, that should work.
