### PR TITLE
fix(edit): rotated avatars after adjuster

### DIFF
--- a/app/src/main/java/friendly/android/AvatarAdjuster.kt
+++ b/app/src/main/java/friendly/android/AvatarAdjuster.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
-import androidx.exifinterface.media.ExifInterface
 import android.net.Uri
 import androidx.core.graphics.scale
+import androidx.exifinterface.media.ExifInterface
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -45,7 +45,13 @@ class AvatarAdjuster(
 
         val croppedDimension = minOf(bitmap.width, bitmap.height)
         val croppedBitmap = Bitmap
-            .createBitmap(rotatedBitmap, 0, 0, croppedDimension, croppedDimension)
+            .createBitmap(
+                rotatedBitmap,
+                0,
+                0,
+                croppedDimension,
+                croppedDimension,
+            )
         val scaledBitmap = croppedBitmap
             .scale(NewAvatarDimension, NewAvatarDimension)
 
@@ -69,21 +75,33 @@ class AvatarAdjuster(
         )
     }
 
-    private fun getRotationDegrees(uri: Uri): Int {
-        return contentResolver.openInputStream(uri)?.use { stream ->
+    private fun getRotationDegrees(uri: Uri): Int =
+        contentResolver.openInputStream(uri)?.use { stream ->
             val exif = ExifInterface(stream)
-            when (exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)) {
+            when (
+                exif.getAttributeInt(
+                    ExifInterface.TAG_ORIENTATION,
+                    ExifInterface.ORIENTATION_NORMAL,
+                )
+            ) {
                 ExifInterface.ORIENTATION_ROTATE_90 -> 90
                 ExifInterface.ORIENTATION_ROTATE_180 -> 180
                 ExifInterface.ORIENTATION_ROTATE_270 -> 270
                 else -> 0
             }
         } ?: 0
-    }
 
     private fun rotateBitmapIfNeeded(bitmap: Bitmap, degrees: Int): Bitmap {
         if (degrees == 0) return bitmap
         val matrix = Matrix().apply { postRotate(degrees.toFloat()) }
-        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+        return Bitmap.createBitmap(
+            bitmap,
+            0,
+            0,
+            bitmap.width,
+            bitmap.height,
+            matrix,
+            true,
+        )
     }
 }

--- a/app/src/main/java/friendly/android/AvatarAdjuster.kt
+++ b/app/src/main/java/friendly/android/AvatarAdjuster.kt
@@ -3,6 +3,8 @@ package friendly.android
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import androidx.exifinterface.media.ExifInterface
 import android.net.Uri
 import androidx.core.graphics.scale
 import java.io.ByteArrayInputStream
@@ -31,11 +33,19 @@ class AvatarAdjuster(
         uri: Uri,
         inputStream: InputStream,
     ): Pair<InputStream, Long> {
+        /* Extract EXIF metadata to fix orientation issues.
+         * Some device cameras save images rotated sideways alongside an EXIF orientation flag
+         * rather than encoding the physical pixel array right-side up.
+         */
+        val rotationDegrees = getRotationDegrees(uri)
+
         val bitmap = BitmapFactory.decodeStream(inputStream)
             ?: error("Failed to decode image")
+        val rotatedBitmap = rotateBitmapIfNeeded(bitmap, rotationDegrees)
+
         val croppedDimension = minOf(bitmap.width, bitmap.height)
         val croppedBitmap = Bitmap
-            .createBitmap(bitmap, 0, 0, croppedDimension, croppedDimension)
+            .createBitmap(rotatedBitmap, 0, 0, croppedDimension, croppedDimension)
         val scaledBitmap = croppedBitmap
             .scale(NewAvatarDimension, NewAvatarDimension)
 
@@ -57,5 +67,23 @@ class AvatarAdjuster(
             first = ByteArrayInputStream(outputStream.toByteArray()),
             second = byteArray.size.toLong(),
         )
+    }
+
+    private fun getRotationDegrees(uri: Uri): Int {
+        return contentResolver.openInputStream(uri)?.use { stream ->
+            val exif = ExifInterface(stream)
+            when (exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)) {
+                ExifInterface.ORIENTATION_ROTATE_90 -> 90
+                ExifInterface.ORIENTATION_ROTATE_180 -> 180
+                ExifInterface.ORIENTATION_ROTATE_270 -> 270
+                else -> 0
+            }
+        } ?: 0
+    }
+
+    private fun rotateBitmapIfNeeded(bitmap: Bitmap, degrees: Int): Bitmap {
+        if (degrees == 0) return bitmap
+        val matrix = Matrix().apply { postRotate(degrees.toFloat()) }
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
     }
 }


### PR DESCRIPTION
Description: Current implementation of `AvatarAdjuster` wipes out all EXIF information, but some phone cameras store orientation (rotation) of camera in that metadata.

Fix: Implemented a way to get rotation angle and apply it to bitmap.